### PR TITLE
Change function name from calculate to calc (#39)

### DIFF
--- a/mathinterpreter/__init__.py
+++ b/mathinterpreter/__init__.py
@@ -1,4 +1,4 @@
-from mathinterpreter.calculate import calculate
+from mathinterpreter.calculate import calc
 from mathinterpreter.interpreter import Interpreter
 from mathinterpreter.lexer import Lexer
 from mathinterpreter.parser import Parser

--- a/mathinterpreter/__main__.py
+++ b/mathinterpreter/__main__.py
@@ -1,4 +1,4 @@
-from mathinterpreter.calculate import calculate
+from mathinterpreter.calculate import calc
 
 
 def main():
@@ -10,7 +10,7 @@ def main():
             if text in ["q", "quit"]:
                 break
 
-        value = calculate(text)
+        value = calc(text)
         print(value)
 
 

--- a/mathinterpreter/calculate.py
+++ b/mathinterpreter/calculate.py
@@ -3,7 +3,7 @@ from mathinterpreter.lexer import Lexer
 from mathinterpreter.parser import Parser
 
 
-def calculate(text):
+def calc(text):
     """
     mathinterpreter's calculator
 

--- a/tests/calculate_test.py
+++ b/tests/calculate_test.py
@@ -1,13 +1,14 @@
 import pytest
-from mathinterpreter.calculate import calculate
+
+from mathinterpreter.calculate import calc
 
 
 class TestCalculate:
 
     def test_numbers(self):
-        value = calculate("51.2")
+        value = calc("51.2")
         assert value == "51.2"
 
     def test_expression(self):
-        value = float(calculate("0 + 10/3"))
+        value = float(calc("0 + 10/3"))
         pytest.approx(value, 3.33, 2)

--- a/tests/calculate_test.py
+++ b/tests/calculate_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mathinterpreter.calculate import calc
+from mathinterpreter import calc
 
 
 class TestCalculate:


### PR DESCRIPTION
Since the function calculete had the same name as the module it was impossible to call it on a higher level scope.

Changed the name to calc.

closes #39