### PR TITLE
Add github actions for black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,4 +10,3 @@ jobs:
       - uses: psf/black@stable
         with:
            options: "--check --verbose"
-           use_pyproject: true

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,9 +1,9 @@
-name: Lint
+name: Formatter
 
 on: [push, pull_request]
 
 jobs:
-  lint:
+  formatter:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,13 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: psf/black@stable
+        with:
+           options: "--check --verbose"
+           use_pyproject: true

--- a/README.md
+++ b/README.md
@@ -65,13 +65,12 @@ For using `mathinterpreter` as a library you will need to import the lexer, the 
 - tests using pytest.
 - a simple simple REPL interface.
 - automated tests using GitHub Actions;
-- format code using with black;
+- format code using with black; with automations on GitHub Actions;
 
 **Current goal is:**
 
-Please check it out the issues, but we aim to implement:
+We track feature requests with issues. But we aim to implement:
 
-- add CI automation for black code formatter;
 - implement code coverage;
 - expand the tests suit;
 - improve the cli:


### PR DESCRIPTION
Despite the code on black documentation, I decided to updated the checkout actions from version 3 to version 4. Since this is the same as used with pytest.